### PR TITLE
New curriculum cleanup

### DIFF
--- a/.index.solution.js
+++ b/.index.solution.js
@@ -2,241 +2,115 @@
  * Morning Challenge
  * Objects, Arrays and Array methods
  *
- * Your task is to complete as many of the functions below as you can, using the
- * instructions provided in the comments.
- *
- * The following is NOT ALLOWED:
- * > `for` loops
- * > `while` loops
- * > `Array.push`
- * > The `delete` keyword
- *
- * Instead, try to use array methods like `.map`, `.filter` and `.reduce`
- *
- * The purpose of this challenge is to get used to manipulating data, and also
- * to get used to using array methods.
  */
 "use strict";
-
-// INSTRUCTIONS
-// DO NOT UNCOMMENT THIS CODE
-//
-// All the functions you must write will take as one of their arguments an
-// Object. This object contains some information about some buildings. The key
-// of the object will be the ID of the building, and the value will be an object
-// with various properties describing the building. You can see an example of
-// what this object looks like below:
-//
-//
-// var buildings = {
-//   14358: {
-//     address: '1010 Yorkshire Circle, Rocky Mount, North Carolina, 75141',
-//     rooms: 3,
-//     value: 450000,
-//   },
-//   98343: {
-//     address: '2367 Parkway Street, Palm Springs, California, 92262',
-//     rooms: 2,
-//     value: 375000,
-//   },
-//   ...
-//   01942: {
-//     address: '4079 Dola Mine Road, Raleigh, North Carolina, 27601',
-//     rooms: 3,
-//     value: 413000,
-//   },
-//   73826: {
-//     address: '3979 Sunrise Road, SCHELL CITY, Missouri, 64783',
-//     rooms: 4,
-//     value: 490000,
-//   },
-//   87536: {
-//     address: '738 Paradise Lane, Claremont, California, 91711',
-//     rooms: 7,
-//     value: 1200000,
-//   },
-// };
-//
-// This is just an example, but you can use it to decide how you will complete
-// the functions below.
 
 // ==========
 // QUESTION 1
 // ==========
-// This function should take the buildings object (`bldngs`) and return an array
-// of objects that each describe a building. Using the `buildings` object above
-// as an example input, this function would return:
-// [
-//   {
-//     address: '1010 Yorkshire Circle, Rocky Mount, North Carolina, 75141',
-//     rooms: 3,
-//     value: 450000,
-//   },
-//   {
-//     address: '2367 Parkway Street, Palm Springs, California, 92262',
-//     rooms: 2,
-//     value: 375000,
-//   },
-//   ...
-// ]
 function getListOfBuildingObjects(bldngs) {
-  return Object.keys(bldngs).map(function(id) {
-    return bldngs[id];
-  });
+  return Object.values(bldngs);
 }
 
 // ==========
 // QUESTION 2
 // ==========
-// This function should take the buildings object (`bldngs`) and return an array
-// of strings where each string is the building address. Using the `buildings`
-// object above as an example input, this function would return:
-// [
-//   '1010 Yorkshire Circle, Rocky Mount, North Carolina, 75141',
-//   '2367 Parkway Street, Palm Springs, California, 92262',
-//   ...
-// ]
 function getListOfBuildingAddresses(bldngs) {
-  return Object.keys(bldngs).map(function(id) {
-    return bldngs[id].address;
-  });
+  return Object.values(bldngs).map(building => building.address);
 }
 
 // ==========
 // QUESTION 3
 // ==========
-// This function should take the buildings object (`bldngs`) and a number
-// (`minValue`), and should return an object that contains only those buildings
-// that have a value at least as big as that given in `minValue`.
-//
-// Using the `buildings` object above as an example input, and assuming
-// `minValue` = 400000, this function should return:
-//
-// {
-//   14358: {
-//     address: '1010 Yorkshire Circle, Rocky Mount, North Carolina, 75141',
-//     rooms: 3,
-//     value: 450000,
-//   },
-// }
 function filterBuildingsByMinValue(bldngs, minValue) {
-  return Object.keys(bldngs)
-    .filter(function(id) {
-      return bldngs[id].value >= minValue;
-    })
-    .reduce(function(acc, id) {
-      acc[id] = bldngs[id];
-      return acc;
-    }, {});
+  function filterBuildings(newBuildings, id) {
+    if (bldngs[id].value >= minValue) newBuildings[id] = bldngs[id];
+    return newBuildings;
+  }
+  return Object.keys(bldngs).reduce(filterBuildings, {});
 }
+
+// Alternative answer without reduce:
+// function filterBuildingsByMinValue(bldngs, minValue) {
+//   const entriesArray = Object.entries(bldngs);
+//   const filteredArray = entriesArray.filter(([id, building]) => building.value >= minValue);
+//   return Object.fromEntries(filteredArray);
+// }
 
 // ==========
 // QUESTION 4
 // ==========
-// This function should take the buildings object (`bldngs`) and a number
-// (`maxRooms`), and should return an object that contains only those buildings
-// that have a number of rooms no bigger than `maxRooms`.
-//
-// Using the `buildings` object above as an example input, and assuming
-// `maxRooms` = 2, this function should return:
-//
-// {
-//   98343: {
-//     address: '2367 Parkway Street, Palm Springs, California, 92262',
-//     rooms: 2,
-//     value: 375000,
-//   },
-// }
 function filterBuildingsByMaxRooms(bldngs, maxRooms) {
-  return Object.keys(bldngs)
-    .filter(function(id) {
-      return bldngs[id].rooms <= maxRooms;
-    })
-    .reduce(function(acc, id) {
-      acc[id] = bldngs[id];
-      return acc;
-    }, {});
+  function filterBuildings(newBuildings, id) {
+    if (bldngs[id].rooms <= maxRooms) newBuildings[id] = bldngs[id];
+    return newBuildings;
+  }
+  return Object.keys(bldngs).reduce(filterBuildings, {});
 }
+
+// Alternative answer without reduce:
+// function filterBuildingsByMaxRooms(bldngs, maxRooms) {
+//   const entriesArray = Object.entries(bldngs);
+//   const filteredArray = entriesArray.filter(([id, building]) => building.rooms <= maxRooms);
+//   return Object.fromEntries(filteredArray);
+// }
 
 // ==========
 // QUESTION 5
 // ==========
-// This function should take the buildings object (`bldngs`), and should return
-// an object that contains all the buildings objects, with an extra key added
-// called `id`, whose value is the top-level key of the object.
-//
-// Using the `buildings` object above as an example input, this function should
-// return:
-//
-// {
-//   14358: {
-//     id: 14358,
-//     address: '1010 Yorkshire Circle, Rocky Mount, North Carolina, 75141',
-//     rooms: 3,
-//     value: 450000,
-//   },
-//   98343: {
-//     id: 98343,
-//     address: '2367 Parkway Street, Palm Springs, California, 92262',
-//     rooms: 2,
-//     value: 375000,
-//   },
-// }
 function addBuildingIdsToObjects(bldngs) {
-  return Object.keys(bldngs).reduce(function(acc, id) {
-    return Object.assign(acc, { [id]: Object.assign({ id: +id }, bldngs[id]) });
-  }, {});
+  function addIdToBuilding(acc, id) {
+    const newBuilding = Object.assign({ id: +id }, bldngs[id]);
+    return Object.assign(acc, { [id]: newBuilding });
+  }
+  return Object.keys(bldngs).reduce(addIdToBuilding, {});
 }
+
+// Alternative solution without reduce:
+// function addBuildingIdsToObjects(bldngs) {
+//   function addIdToBuilding([id, building]) {
+//     const newBuilding = Object.assign({}, building, { id: parseInt(id, 10) });
+//     return [id, newBuilding];
+//   }
+//   const entries = Object.entries(bldngs).map(addIdToBuilding);
+//   return Object.fromEntries(entries);
+// }
 
 // ==========
 // QUESTION 6
 // ==========
-// This function should take the buildings object (`bldngs`), and should return
-// an object that contains all the buildings objects, but where the value of the
-// `address` key is an object, whose keys are `street`, `town`, `state` and
-// `zipcode`.
-//
-// Using the `buildings` object above as an example input, this function should
-// return:
-//
-// {
-//   14358: {
-//     address: {
-//       street: '1010 Yorkshire Circle',
-//       town: 'Rocky Mount',
-//       state: 'North Carolina',
-//       zipcode: 75141,
-//     },
-//     rooms: 3,
-//     value: 450000,
-//   },
-//   98343: {
-//     address: {
-//       street: '2367 Parkway Street',
-//       town: 'Palm Springs',
-//       state: 'California',
-//       zipcode: 92262,
-//     },
-//     rooms: 2,
-//     value: 375000,
-//   },
-// }
 function parseBuildingAddresses(bldngs) {
-  return Object.keys(bldngs).reduce(function(acc, id) {
-    var addressParts = bldngs[id].address.split(",").map(function(s) {
-      return s.trim();
+  function makeAddressObject(address) {
+    const [street, town, state, zipcode] = address
+      .split(",")
+      .map(s => s.trim());
+    return { street, town, state, zipcode: parseInt(zipcode, 10) };
+  }
+  function changeBuildingAddress(newBuilding, id) {
+    const address = makeAddressObject(bldngs[id].address);
+    return Object.assign(newBuilding, {
+      [id]: Object.assign({}, bldngs[id], { address }),
     });
-    var addressObject = {
-      street: addressParts[0],
-      town: addressParts[1],
-      state: addressParts[2],
-      zipcode: +addressParts[3],
-    };
-    return Object.assign(acc, {
-      [id]: Object.assign({}, bldngs[id], { address: addressObject }),
-    });
-  }, {});
+  }
+  return Object.keys(bldngs).reduce(changeBuildingAddress, {});
 }
+
+// Alternative solution without reduce:
+// function parseBuildingAddresses(bldngs) {
+//   function makeAddressObject(address) {
+//     const [street, town, state, zipcode] = address
+//       .split(",")
+//       .map(s => s.trim());
+//     return { street, town, state, zipcode: parseInt(zipcode, 10) };
+//   }
+//   function addAddressToBuilding([id, building]) {
+//     const address = makeAddressObject(building.address);
+//     const newBuilding = Object.assign({}, building, { address });
+//     return [id, newBuilding];
+//   }
+//   const entries = Object.entries(bldngs).map(addAddressToBuilding);
+//   return Object.fromEntries(entries);
+// }
 
 module.exports = {
   getListOfBuildingObjects,

--- a/.index.solution.js
+++ b/.index.solution.js
@@ -50,7 +50,7 @@
 //     rooms: 4,
 //     value: 490000,
 //   },
-//   73826: {
+//   87536: {
 //     address: '738 Paradise Lane, Claremont, California, 91711',
 //     rooms: 7,
 //     value: 1200000,

--- a/.index.solution.js
+++ b/.index.solution.js
@@ -16,7 +16,7 @@
  * The purpose of this challenge is to get used to manipulating data, and also
  * to get used to using array methods.
  */
-'use strict';
+"use strict";
 
 // INSTRUCTIONS
 // DO NOT UNCOMMENT THIS CODE
@@ -60,7 +60,6 @@
 // This is just an example, but you can use it to decide how you will complete
 // the functions below.
 
-
 // This function should take the buildings object (`bldngs`) and return an array
 // of objects that each describe a building. Using the `buildings` object above
 // as an example input, this function would return:
@@ -78,9 +77,10 @@
 //   ...
 // ]
 function getListOfBuildingObjects(bldngs) {
-  return Object.keys(bldngs).map(function (id) { return bldngs[id]; });
+  return Object.keys(bldngs).map(function(id) {
+    return bldngs[id];
+  });
 }
-
 
 // This function should take the buildings object (`bldngs`) and return an array
 // of strings where each string is the building address. Using the `buildings`
@@ -91,9 +91,10 @@ function getListOfBuildingObjects(bldngs) {
 //   ...
 // ]
 function getListOfBuildingAddresses(bldngs) {
-  return Object.keys(bldngs).map(function (id) { return bldngs[id].address; });
+  return Object.keys(bldngs).map(function(id) {
+    return bldngs[id].address;
+  });
 }
-
 
 // This function should take the buildings object (`bldngs`) and a number
 // (`minValue`), and should return an object that contains only those buildings
@@ -111,13 +112,14 @@ function getListOfBuildingAddresses(bldngs) {
 // }
 function filterBuildingsByMinValue(bldngs, minValue) {
   return Object.keys(bldngs)
-    .filter(function (id) { return bldngs[id].value >= minValue; })
-    .reduce(function (acc, id) {
+    .filter(function(id) {
+      return bldngs[id].value >= minValue;
+    })
+    .reduce(function(acc, id) {
       acc[id] = bldngs[id];
       return acc;
     }, {});
 }
-
 
 // This function should take the buildings object (`bldngs`) and a number
 // (`maxRooms`), and should return an object that contains only those buildings
@@ -135,13 +137,14 @@ function filterBuildingsByMinValue(bldngs, minValue) {
 // }
 function filterBuildingsByMaxRooms(bldngs, maxRooms) {
   return Object.keys(bldngs)
-    .filter(function (id) { return bldngs[id].rooms <= maxRooms; })
-    .reduce(function (acc, id) {
+    .filter(function(id) {
+      return bldngs[id].rooms <= maxRooms;
+    })
+    .reduce(function(acc, id) {
       acc[id] = bldngs[id];
       return acc;
     }, {});
 }
-
 
 // This function should take the buildings object (`bldngs`), and should return
 // an object that contains all the buildings objects, with an extra key added
@@ -165,12 +168,10 @@ function filterBuildingsByMaxRooms(bldngs, maxRooms) {
 //   },
 // }
 function addBuildingIdsToObjects(bldngs) {
-  return Object.keys(bldngs)
-    .reduce(function (acc, id) {
-      return Object.assign(acc, { [id]: Object.assign({ id: +id }, bldngs[id]) });
-    }, {});
+  return Object.keys(bldngs).reduce(function(acc, id) {
+    return Object.assign(acc, { [id]: Object.assign({ id: +id }, bldngs[id]) });
+  }, {});
 }
-
 
 // This function should take the buildings object (`bldngs`), and should return
 // an object that contains all the buildings objects, but where the value of the
@@ -203,19 +204,21 @@ function addBuildingIdsToObjects(bldngs) {
 //   },
 // }
 function parseBuildingAddresses(bldngs) {
-  return Object.keys(bldngs)
-    .reduce(function (acc, id) {
-      var addressParts = bldngs[id].address.split(',').map(function (s) { return s.trim(); });
-      var addressObject = {
-        street: addressParts[0],
-        town: addressParts[1],
-        state: addressParts[2],
-        zipcode: +addressParts[3],
-      };
-      return Object.assign(acc, { [id]: Object.assign({}, bldngs[id], { address: addressObject }) });
-    }, {});
+  return Object.keys(bldngs).reduce(function(acc, id) {
+    var addressParts = bldngs[id].address.split(",").map(function(s) {
+      return s.trim();
+    });
+    var addressObject = {
+      street: addressParts[0],
+      town: addressParts[1],
+      state: addressParts[2],
+      zipcode: +addressParts[3],
+    };
+    return Object.assign(acc, {
+      [id]: Object.assign({}, bldngs[id], { address: addressObject }),
+    });
+  }, {});
 }
-
 
 module.exports = {
   getListOfBuildingObjects,

--- a/.index.solution.js
+++ b/.index.solution.js
@@ -60,6 +60,9 @@
 // This is just an example, but you can use it to decide how you will complete
 // the functions below.
 
+// ==========
+// QUESTION 1
+// ==========
 // This function should take the buildings object (`bldngs`) and return an array
 // of objects that each describe a building. Using the `buildings` object above
 // as an example input, this function would return:
@@ -82,6 +85,9 @@ function getListOfBuildingObjects(bldngs) {
   });
 }
 
+// ==========
+// QUESTION 2
+// ==========
 // This function should take the buildings object (`bldngs`) and return an array
 // of strings where each string is the building address. Using the `buildings`
 // object above as an example input, this function would return:
@@ -96,6 +102,9 @@ function getListOfBuildingAddresses(bldngs) {
   });
 }
 
+// ==========
+// QUESTION 3
+// ==========
 // This function should take the buildings object (`bldngs`) and a number
 // (`minValue`), and should return an object that contains only those buildings
 // that have a value at least as big as that given in `minValue`.
@@ -121,6 +130,9 @@ function filterBuildingsByMinValue(bldngs, minValue) {
     }, {});
 }
 
+// ==========
+// QUESTION 4
+// ==========
 // This function should take the buildings object (`bldngs`) and a number
 // (`maxRooms`), and should return an object that contains only those buildings
 // that have a number of rooms no bigger than `maxRooms`.
@@ -146,6 +158,9 @@ function filterBuildingsByMaxRooms(bldngs, maxRooms) {
     }, {});
 }
 
+// ==========
+// QUESTION 5
+// ==========
 // This function should take the buildings object (`bldngs`), and should return
 // an object that contains all the buildings objects, with an extra key added
 // called `id`, whose value is the top-level key of the object.
@@ -173,6 +188,9 @@ function addBuildingIdsToObjects(bldngs) {
   }, {});
 }
 
+// ==========
+// QUESTION 6
+// ==========
 // This function should take the buildings object (`bldngs`), and should return
 // an object that contains all the buildings objects, but where the value of the
 // `address` key is an object, whose keys are `street`, `town`, `state` and

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ instructions provided in the comments.
 
 The following is NOT ALLOWED:
 
-* `for` loops
-* `while` loops
-* `Array.push`
-* The `delete` keyword
+- `for` loops
+- `while` loops
+- `Array.push`
+- The `delete` keyword
 
 Instead, try to use array methods like `.map`, `.filter` and `.reduce`.
 

--- a/index.js
+++ b/index.js
@@ -60,6 +60,9 @@
 // This is just an example, but you can use it to decide how you will complete
 // the functions below.
 
+// ==========
+// QUESTION 1
+// ==========
 // This function should take the buildings object (`bldngs`) and return an array
 // of objects that each describe a building. Using the `buildings` object above
 // as an example input, this function would return:
@@ -80,6 +83,9 @@ function getListOfBuildingObjects(bldngs) {
   // CODE HERE
 }
 
+// ==========
+// QUESTION 2
+// ==========
 // This function should take the buildings object (`bldngs`) and return an array
 // of strings where each string is the building address. Using the `buildings`
 // object above as an example input, this function would return:
@@ -92,6 +98,9 @@ function getListOfBuildingAddresses(bldngs) {
   // CODE HERE
 }
 
+// ==========
+// QUESTION 3
+// ==========
 // This function should take the buildings object (`bldngs`) and a number
 // (`minValue`), and should return an object that contains only those buildings
 // that have a value at least as big as that given in `minValue`.
@@ -110,6 +119,9 @@ function filterBuildingsByMinValue(bldngs, minValue) {
   // CODE HERE
 }
 
+// ==========
+// QUESTION 4
+// ==========
 // This function should take the buildings object (`bldngs`) and a number
 // (`maxRooms`), and should return an object that contains only those buildings
 // that have a number of rooms no bigger than `maxRooms`.
@@ -128,6 +140,9 @@ function filterBuildingsByMaxRooms(bldngs, maxRooms) {
   // CODE HERE
 }
 
+// ==========
+// QUESTION 5
+// ==========
 // This function should take the buildings object (`bldngs`), and should return
 // an object that contains all the buildings objects, with an extra key added
 // called `id`, whose value is the top-level key of the object.
@@ -153,6 +168,9 @@ function addBuildingIdsToObjects(bldngs) {
   // CODE HERE
 }
 
+// ==========
+// QUESTION 6
+// ==========
 // This function should take the buildings object (`bldngs`), and should return
 // an object that contains all the buildings objects, but where the value of the
 // `address` key is an object, whose keys are `street`, `town`, `state` and

--- a/index.js
+++ b/index.js
@@ -146,6 +146,7 @@ function filterBuildingsByMaxRooms(bldngs, maxRooms) {
 // This function should take the buildings object (`bldngs`), and should return
 // an object that contains all the buildings objects, with an extra key added
 // called `id`, whose value is the top-level key of the object.
+// id should be a number, not a string
 //
 // Using the `buildings` object above as an example input, this function should
 // return:
@@ -175,6 +176,7 @@ function addBuildingIdsToObjects(bldngs) {
 // an object that contains all the buildings objects, but where the value of the
 // `address` key is an object, whose keys are `street`, `town`, `state` and
 // `zipcode`.
+// Zipcode should be a number, not a string
 //
 // Using the `buildings` object above as an example input, this function should
 // return:

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@
 //     rooms: 4,
 //     value: 490000,
 //   },
-//   73826: {
+//   87536: {
 //     address: '738 Paradise Lane, Claremont, California, 91711',
 //     rooms: 7,
 //     value: 1200000,

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@
  * The purpose of this challenge is to get used to manipulating data, and also
  * to get used to using array methods.
  */
-'use strict';
+"use strict";
 
 // INSTRUCTIONS
 // DO NOT UNCOMMENT THIS CODE
@@ -60,7 +60,6 @@
 // This is just an example, but you can use it to decide how you will complete
 // the functions below.
 
-
 // This function should take the buildings object (`bldngs`) and return an array
 // of objects that each describe a building. Using the `buildings` object above
 // as an example input, this function would return:
@@ -77,10 +76,9 @@
 //   },
 //   ...
 // ]
-function getListOfBuildingObjects (bldngs) {
+function getListOfBuildingObjects(bldngs) {
   // CODE HERE
 }
-
 
 // This function should take the buildings object (`bldngs`) and return an array
 // of strings where each string is the building address. Using the `buildings`
@@ -90,10 +88,9 @@ function getListOfBuildingObjects (bldngs) {
 //   '2367 Parkway Street, Palm Springs, California, 92262',
 //   ...
 // ]
-function getListOfBuildingAddresses (bldngs) {
+function getListOfBuildingAddresses(bldngs) {
   // CODE HERE
 }
-
 
 // This function should take the buildings object (`bldngs`) and a number
 // (`minValue`), and should return an object that contains only those buildings
@@ -109,10 +106,9 @@ function getListOfBuildingAddresses (bldngs) {
 //     value: 450000,
 //   },
 // }
-function filterBuildingsByMinValue (bldngs, minValue) {
+function filterBuildingsByMinValue(bldngs, minValue) {
   // CODE HERE
 }
-
 
 // This function should take the buildings object (`bldngs`) and a number
 // (`maxRooms`), and should return an object that contains only those buildings
@@ -128,10 +124,9 @@ function filterBuildingsByMinValue (bldngs, minValue) {
 //     value: 375000,
 //   },
 // }
-function filterBuildingsByMaxRooms (bldngs, maxRooms) {
+function filterBuildingsByMaxRooms(bldngs, maxRooms) {
   // CODE HERE
 }
-
 
 // This function should take the buildings object (`bldngs`), and should return
 // an object that contains all the buildings objects, with an extra key added
@@ -154,10 +149,9 @@ function filterBuildingsByMaxRooms (bldngs, maxRooms) {
 //     value: 375000,
 //   },
 // }
-function addBuildingIdsToObjects (bldngs) {
+function addBuildingIdsToObjects(bldngs) {
   // CODE HERE
 }
-
 
 // This function should take the buildings object (`bldngs`), and should return
 // an object that contains all the buildings objects, but where the value of the
@@ -189,10 +183,9 @@ function addBuildingIdsToObjects (bldngs) {
 //     value: 375000,
 //   },
 // }
-function parseBuildingAddresses (bldngs) {
+function parseBuildingAddresses(bldngs) {
   // CODE HERE
 }
-
 
 module.exports = {
   getListOfBuildingObjects,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,657 @@
+{
+  "name": "mc-objects-and-arrays",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "buffer-shims": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
+      "dev": true
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "deep-equal": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+      "dev": true,
+      "requires": {
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0"
+      }
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
+    "defined": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+      "dev": true
+    },
+    "dotignore": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dotignore/-/dotignore-0.1.2.tgz",
+      "integrity": "sha512-UGGGWfSauusaVJC+8fgV+NVvBXkCTmVv7sk6nojDZZvuOUNGUy0Zk4UpHQD6EDjS0jpBwcACvH4eofvyzBcRDw==",
+      "dev": true,
+      "requires": {
+        "minimatch": "^3.0.4"
+      }
+    },
+    "duplexer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+      "dev": true
+    },
+    "es-abstract": {
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
+      "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.1.5",
+        "is-regex": "^1.0.5",
+        "object-inspect": "^1.7.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.0",
+        "string.prototype.trimleft": "^2.1.1",
+        "string.prototype.trimright": "^2.1.1"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "figures": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
+      }
+    },
+    "for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.3"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "has-symbols": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "is-arguments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
+      "dev": true
+    },
+    "is-callable": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+      "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+      "dev": true
+    },
+    "is-date-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+      "dev": true
+    },
+    "is-finite": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
+      "dev": true
+    },
+    "is-regex": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+      "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.1"
+      }
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "object-inspect": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+      "dev": true
+    },
+    "object-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.2.tgz",
+      "integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ==",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "parse-ms": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz",
+      "integrity": "sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0=",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "plur": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/plur/-/plur-1.0.0.tgz",
+      "integrity": "sha1-24XGgU9eXlo7Se/CjWBP7GKXUVY=",
+      "dev": true
+    },
+    "pretty-ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-2.1.0.tgz",
+      "integrity": "sha1-QlfCVt8/sLRR1q/6qwIYhBJpgdw=",
+      "dev": true,
+      "requires": {
+        "is-finite": "^1.0.1",
+        "parse-ms": "^1.0.0",
+        "plur": "^1.0.0"
+      }
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+      "dev": true
+    },
+    "re-emitter": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/re-emitter/-/re-emitter-1.1.3.tgz",
+      "integrity": "sha1-+p4xn/3u6zWycpbvDz03TawvUqc=",
+      "dev": true
+    },
+    "readable-stream": {
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+      "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
+      "dev": true,
+      "requires": {
+        "buffer-shims": "~1.0.0",
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "string_decoder": "~1.0.0",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "regexp.prototype.flags": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
+      "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
+      }
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
+    "resolve": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
+      "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
+    },
+    "resumer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+      "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
+      "dev": true,
+      "requires": {
+        "through": "~2.3.4"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "split": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.0.tgz",
+      "integrity": "sha1-xDlc5oOrzSVLwo/h2rtuXCfc/64=",
+      "dev": true,
+      "requires": {
+        "through": "2"
+      }
+    },
+    "string.prototype.trim": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.1.tgz",
+      "integrity": "sha512-MjGFEeqixw47dAMFMtgUro/I0+wNqZB5GKXGt1fFr24u3TzDXCPu7J9Buppzoe3r/LqkSDLDDJzE15RGWDGAVw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1",
+        "function-bind": "^1.1.1"
+      }
+    },
+    "string.prototype.trimend": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.0.tgz",
+      "integrity": "sha512-EEJnGqa/xNfIg05SxiPSqRS7S9qwDhYts1TSLR1BQfYUfPe1stofgGKvwERK9+9yf+PpfBMlpBaCHucXGPQfUA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "string.prototype.trimleft": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
+      "integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5",
+        "string.prototype.trimstart": "^1.0.0"
+      }
+    },
+    "string.prototype.trimright": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
+      "integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5",
+        "string.prototype.trimend": "^1.0.0"
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.0.tgz",
+      "integrity": "sha512-iCP8g01NFYiiBOnwG1Xc3WZLyoo+RuBymwIlWncShXDDJYWN6DbnM3odslBJdgCdRlq94B5s63NWAZlcn2CS4w==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
+    },
+    "tap-out": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tap-out/-/tap-out-2.1.0.tgz",
+      "integrity": "sha512-LJE+TBoVbOWhwdz4+FQk40nmbIuxJLqaGvj3WauQw3NYYU5TdjoV3C0x/yq37YAvVyi+oeBXmWnxWSjJ7IEyUw==",
+      "dev": true,
+      "requires": {
+        "re-emitter": "1.1.3",
+        "readable-stream": "2.2.9",
+        "split": "1.0.0",
+        "trim": "0.0.1"
+      }
+    },
+    "tap-spec": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/tap-spec/-/tap-spec-5.0.0.tgz",
+      "integrity": "sha512-zMDVJiE5I6Y4XGjlueGXJIX2YIkbDN44broZlnypT38Hj/czfOXrszHNNJBF/DXR8n+x6gbfSx68x04kIEHdrw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.0.0",
+        "duplexer": "^0.1.1",
+        "figures": "^1.4.0",
+        "lodash": "^4.17.10",
+        "pretty-ms": "^2.1.0",
+        "repeat-string": "^1.5.2",
+        "tap-out": "^2.1.0",
+        "through2": "^2.0.0"
+      }
+    },
+    "tape": {
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-4.13.2.tgz",
+      "integrity": "sha512-waWwC/OqYVE9TS6r1IynlP2sEdk4Lfo6jazlgkuNkPTHIbuG2BTABIaKdlQWwPeB6Oo4ksZ1j33Yt0NTOAlYMQ==",
+      "dev": true,
+      "requires": {
+        "deep-equal": "~1.1.1",
+        "defined": "~1.0.0",
+        "dotignore": "~0.1.2",
+        "for-each": "~0.3.3",
+        "function-bind": "~1.1.1",
+        "glob": "~7.1.6",
+        "has": "~1.0.3",
+        "inherits": "~2.0.4",
+        "is-regex": "~1.0.5",
+        "minimist": "~1.2.0",
+        "object-inspect": "~1.7.0",
+        "resolve": "~1.15.1",
+        "resumer": "~0.0.0",
+        "string.prototype.trim": "~1.2.1",
+        "through": "~2.3.8"
+      }
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "dev": true,
+      "requires": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      },
+      "dependencies": {
+        "process-nextick-args": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "trim": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
+      "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true
+    }
+  }
+}

--- a/tests.js
+++ b/tests.js
@@ -1,208 +1,213 @@
-'use strict';
+"use strict";
 
-var tape = require('tape');
-var fns = require('./index.js');
+var tape = require("tape");
+var fns = require("./index.js");
 
 var buildings = {
   14358: {
-    address: '1010 Yorkshire Circle, Rocky Mount, North Carolina, 75141',
+    address: "1010 Yorkshire Circle, Rocky Mount, North Carolina, 75141",
     rooms: 3,
     value: 450000,
   },
   98343: {
-    address: '2367 Parkway Street, Palm Springs, California, 92262',
+    address: "2367 Parkway Street, Palm Springs, California, 92262",
     rooms: 2,
     value: 375000,
   },
   51942: {
-    address: '4079 Dola Mine Road, Raleigh, North Carolina, 27601',
+    address: "4079 Dola Mine Road, Raleigh, North Carolina, 27601",
     rooms: 3,
     value: 413000,
   },
   73826: {
-    address: '3979 Sunrise Road, SCHELL CITY, Missouri, 64783',
+    address: "3979 Sunrise Road, SCHELL CITY, Missouri, 64783",
     rooms: 4,
     value: 490000,
   },
   73826: {
-    address: '738 Paradise Lane, Claremont, California, 91711',
+    address: "738 Paradise Lane, Claremont, California, 91711",
     rooms: 7,
     value: 1200000,
   },
 };
 
-
-tape('getListOfBuildingObjects', function (t) {
+tape("getListOfBuildingObjects", function(t) {
   var result = fns.getListOfBuildingObjects(buildings);
 
-  t.equal(result.length, Object.keys(buildings).length, 'Should have the right number of buildings');
+  t.equal(
+    result.length,
+    Object.keys(buildings).length,
+    "Should have the right number of buildings"
+  );
 
-  Object.keys(buildings).forEach(function (id) {
-    t.ok(result.includes(buildings[id]), 'List should include building ' + id);
+  Object.keys(buildings).forEach(function(id) {
+    t.ok(result.includes(buildings[id]), "List should include building " + id);
   });
 
   t.end();
 });
 
-
-tape('getListOfBuildingAddresses', function (t) {
+tape("getListOfBuildingAddresses", function(t) {
   var result = fns.getListOfBuildingAddresses(buildings);
 
-  t.equal(result.length, Object.keys(buildings).length, 'Should have the right number of buildings');
+  t.equal(
+    result.length,
+    Object.keys(buildings).length,
+    "Should have the right number of buildings"
+  );
 
-  Object.keys(buildings).forEach(function (id) {
-    t.ok(result.includes(buildings[id].address), 'List should include ' + buildings[id].address);
+  Object.keys(buildings).forEach(function(id) {
+    t.ok(
+      result.includes(buildings[id].address),
+      "List should include " + buildings[id].address
+    );
   });
 
   t.end();
 });
 
-
-tape('filterBuildingsByMinValue', function (t) {
+tape("filterBuildingsByMinValue", function(t) {
   t.deepEqual(
     fns.filterBuildingsByMinValue(buildings, 420000),
     {
       14358: {
-        address: '1010 Yorkshire Circle, Rocky Mount, North Carolina, 75141',
+        address: "1010 Yorkshire Circle, Rocky Mount, North Carolina, 75141",
         rooms: 3,
         value: 450000,
       },
       73826: {
-        address: '3979 Sunrise Road, SCHELL CITY, Missouri, 64783',
+        address: "3979 Sunrise Road, SCHELL CITY, Missouri, 64783",
         rooms: 4,
         value: 490000,
       },
       73826: {
-        address: '738 Paradise Lane, Claremont, California, 91711',
+        address: "738 Paradise Lane, Claremont, California, 91711",
         rooms: 7,
         value: 1200000,
       },
     },
-    'filters out building objects w/ value < 420000'
+    "filters out building objects w/ value < 420000"
   );
 
   t.deepEqual(
     fns.filterBuildingsByMinValue(buildings, 1000000),
     {
       73826: {
-        address: '738 Paradise Lane, Claremont, California, 91711',
+        address: "738 Paradise Lane, Claremont, California, 91711",
         rooms: 7,
         value: 1200000,
       },
     },
-    'filters out building objects w/ value <= 1000000'
+    "filters out building objects w/ value <= 1000000"
   );
   t.end();
 });
 
-
-tape('filterBuildingsByMaxRooms', function (t) {
+tape("filterBuildingsByMaxRooms", function(t) {
   t.deepEqual(
     fns.filterBuildingsByMaxRooms(buildings, 3),
     {
       14358: {
-        address: '1010 Yorkshire Circle, Rocky Mount, North Carolina, 75141',
+        address: "1010 Yorkshire Circle, Rocky Mount, North Carolina, 75141",
         rooms: 3,
         value: 450000,
       },
       98343: {
-        address: '2367 Parkway Street, Palm Springs, California, 92262',
+        address: "2367 Parkway Street, Palm Springs, California, 92262",
         rooms: 2,
         value: 375000,
       },
       51942: {
-        address: '4079 Dola Mine Road, Raleigh, North Carolina, 27601',
+        address: "4079 Dola Mine Road, Raleigh, North Carolina, 27601",
         rooms: 3,
         value: 413000,
       },
     },
-    'filters out building objects w/ rooms >= 3'
+    "filters out building objects w/ rooms >= 3"
   );
   t.end();
 });
 
-
-tape('addBuildingIdsToObjects', function (t) {
+tape("addBuildingIdsToObjects", function(t) {
   t.deepEqual(
     fns.addBuildingIdsToObjects(buildings),
     {
       14358: {
         id: 14358,
-        address: '1010 Yorkshire Circle, Rocky Mount, North Carolina, 75141',
+        address: "1010 Yorkshire Circle, Rocky Mount, North Carolina, 75141",
         rooms: 3,
         value: 450000,
       },
       98343: {
         id: 98343,
-        address: '2367 Parkway Street, Palm Springs, California, 92262',
+        address: "2367 Parkway Street, Palm Springs, California, 92262",
         rooms: 2,
         value: 375000,
       },
       51942: {
         id: 51942,
-        address: '4079 Dola Mine Road, Raleigh, North Carolina, 27601',
+        address: "4079 Dola Mine Road, Raleigh, North Carolina, 27601",
         rooms: 3,
         value: 413000,
       },
       73826: {
         id: 73826,
-        address: '3979 Sunrise Road, SCHELL CITY, Missouri, 64783',
+        address: "3979 Sunrise Road, SCHELL CITY, Missouri, 64783",
         rooms: 4,
         value: 490000,
       },
       73826: {
         id: 73826,
-        address: '738 Paradise Lane, Claremont, California, 91711',
+        address: "738 Paradise Lane, Claremont, California, 91711",
         rooms: 7,
         value: 1200000,
       },
     },
-    'adds id key to each building object'
+    "adds id key to each building object"
   );
   t.deepEqual(
     buildings,
     {
       14358: {
-        address: '1010 Yorkshire Circle, Rocky Mount, North Carolina, 75141',
+        address: "1010 Yorkshire Circle, Rocky Mount, North Carolina, 75141",
         rooms: 3,
-        value: 450000
+        value: 450000,
       },
       98343: {
-        address: '2367 Parkway Street, Palm Springs, California, 92262',
+        address: "2367 Parkway Street, Palm Springs, California, 92262",
         rooms: 2,
-        value: 375000
+        value: 375000,
       },
       51942: {
-        address: '4079 Dola Mine Road, Raleigh, North Carolina, 27601',
+        address: "4079 Dola Mine Road, Raleigh, North Carolina, 27601",
         rooms: 3,
-        value: 413000
+        value: 413000,
       },
       73826: {
-        address: '3979 Sunrise Road, SCHELL CITY, Missouri, 64783',
+        address: "3979 Sunrise Road, SCHELL CITY, Missouri, 64783",
         rooms: 4,
-        value: 490000
+        value: 490000,
       },
       73826: {
-        address: '738 Paradise Lane, Claremont, California, 91711',
+        address: "738 Paradise Lane, Claremont, California, 91711",
         rooms: 7,
-        value: 1200000
-      }
+        value: 1200000,
+      },
     },
-    'Original object has not been mutated'
+    "Original object has not been mutated"
   );
   t.end();
 });
 
-
-tape('parseBuildingAddresses', function (t) {
+tape("parseBuildingAddresses", function(t) {
   t.deepEqual(
     fns.parseBuildingAddresses(buildings),
     {
       14358: {
         address: {
-          street: '1010 Yorkshire Circle',
-          town: 'Rocky Mount',
-          state: 'North Carolina',
+          street: "1010 Yorkshire Circle",
+          town: "Rocky Mount",
+          state: "North Carolina",
           zipcode: 75141,
         },
         rooms: 3,
@@ -210,9 +215,9 @@ tape('parseBuildingAddresses', function (t) {
       },
       98343: {
         address: {
-          street: '2367 Parkway Street',
-          town: 'Palm Springs',
-          state: 'California',
+          street: "2367 Parkway Street",
+          town: "Palm Springs",
+          state: "California",
           zipcode: 92262,
         },
         rooms: 2,
@@ -220,9 +225,9 @@ tape('parseBuildingAddresses', function (t) {
       },
       51942: {
         address: {
-          street: '4079 Dola Mine Road',
-          town: 'Raleigh',
-          state: 'North Carolina',
+          street: "4079 Dola Mine Road",
+          town: "Raleigh",
+          state: "North Carolina",
           zipcode: 27601,
         },
         rooms: 3,
@@ -230,9 +235,9 @@ tape('parseBuildingAddresses', function (t) {
       },
       73826: {
         address: {
-          street: '3979 Sunrise Road',
-          town: 'SCHELL CITY',
-          state: 'Missouri',
+          street: "3979 Sunrise Road",
+          town: "SCHELL CITY",
+          state: "Missouri",
           zipcode: 64783,
         },
         rooms: 4,
@@ -240,47 +245,47 @@ tape('parseBuildingAddresses', function (t) {
       },
       73826: {
         address: {
-          street: '738 Paradise Lane',
-          town: 'Claremont',
-          state: 'California',
+          street: "738 Paradise Lane",
+          town: "Claremont",
+          state: "California",
           zipcode: 91711,
         },
         rooms: 7,
         value: 1200000,
       },
     },
-    'Should parse address field into object'
+    "Should parse address field into object"
   );
   t.deepEqual(
     buildings,
     {
       14358: {
-        address: '1010 Yorkshire Circle, Rocky Mount, North Carolina, 75141',
+        address: "1010 Yorkshire Circle, Rocky Mount, North Carolina, 75141",
         rooms: 3,
-        value: 450000
+        value: 450000,
       },
       98343: {
-        address: '2367 Parkway Street, Palm Springs, California, 92262',
+        address: "2367 Parkway Street, Palm Springs, California, 92262",
         rooms: 2,
-        value: 375000
+        value: 375000,
       },
       51942: {
-        address: '4079 Dola Mine Road, Raleigh, North Carolina, 27601',
+        address: "4079 Dola Mine Road, Raleigh, North Carolina, 27601",
         rooms: 3,
-        value: 413000
+        value: 413000,
       },
       73826: {
-        address: '3979 Sunrise Road, SCHELL CITY, Missouri, 64783',
+        address: "3979 Sunrise Road, SCHELL CITY, Missouri, 64783",
         rooms: 4,
-        value: 490000
+        value: 490000,
       },
       73826: {
-        address: '738 Paradise Lane, Claremont, California, 91711',
+        address: "738 Paradise Lane, Claremont, California, 91711",
         rooms: 7,
-        value: 1200000
-      }
+        value: 1200000,
+      },
     },
-    'Original object has not been mutated'
+    "Original object has not been mutated"
   );
   t.end();
 });

--- a/tests.js
+++ b/tests.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var tape = require("tape");
-var fns = require("./index.js");
+var fns = require("./.index.solution.js");
 
 var buildings = {
   14358: {
@@ -24,7 +24,7 @@ var buildings = {
     rooms: 4,
     value: 490000,
   },
-  73826: {
+  87536: {
     address: "738 Paradise Lane, Claremont, California, 91711",
     rooms: 7,
     value: 1200000,
@@ -80,7 +80,7 @@ tape("filterBuildingsByMinValue", function(t) {
         rooms: 4,
         value: 490000,
       },
-      73826: {
+      87536: {
         address: "738 Paradise Lane, Claremont, California, 91711",
         rooms: 7,
         value: 1200000,
@@ -92,7 +92,7 @@ tape("filterBuildingsByMinValue", function(t) {
   t.deepEqual(
     fns.filterBuildingsByMinValue(buildings, 1000000),
     {
-      73826: {
+      87536: {
         address: "738 Paradise Lane, Claremont, California, 91711",
         rooms: 7,
         value: 1200000,
@@ -156,8 +156,8 @@ tape("addBuildingIdsToObjects", function(t) {
         rooms: 4,
         value: 490000,
       },
-      73826: {
-        id: 73826,
+      87536: {
+        id: 87536,
         address: "738 Paradise Lane, Claremont, California, 91711",
         rooms: 7,
         value: 1200000,
@@ -188,7 +188,7 @@ tape("addBuildingIdsToObjects", function(t) {
         rooms: 4,
         value: 490000,
       },
-      73826: {
+      87536: {
         address: "738 Paradise Lane, Claremont, California, 91711",
         rooms: 7,
         value: 1200000,
@@ -243,7 +243,7 @@ tape("parseBuildingAddresses", function(t) {
         rooms: 4,
         value: 490000,
       },
-      73826: {
+      87536: {
         address: {
           street: "738 Paradise Lane",
           town: "Claremont",
@@ -279,7 +279,7 @@ tape("parseBuildingAddresses", function(t) {
         rooms: 4,
         value: 490000,
       },
-      73826: {
+      87536: {
         address: "738 Paradise Lane, Claremont, California, 91711",
         rooms: 7,
         value: 1200000,


### PR DESCRIPTION
Didn't change anything fundamental, just fixed a few things/clarified stuff.

- Prettier with defaults for consistency
- Change duplicate test data key (fixes #6)
-  Add numbers to questions (some students skipped the first question cause it was buried in comments)
- Remove comments from solutions, since they can refer back to the challenge
- Refactor solutions to use ES6 and arrow fn callbacks (for slightly clearer reading)
- Extract inline reducer callbacks to named functions
   - Reducers are hard enough to read when you know how they work. To students who've never seen one before it's pretty intense. Having a separate named function makes it slightly easier to parse what's going where, and what the accumulator is
   - Also don't use `acc`, there's usually a better name for it
- Also clarified a couple of places where we expect them to convert a string key to a number. This isn't obvious in the test failure since you have to read a huge block of `deepEqual` comparison